### PR TITLE
feat(*): add global PR template

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @collibra/principal-engineering-committee

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+<!--
+Please use this pull request template to outline the work captured in this PR.
+Helpful links:
+Code Review Work Instruction
+https://dg.collibra.com/asset/8706568b-f610-4fbc-bb19-caa2fd5e02dc
+Pull Request Template and Guidelines
+https://engineering-collibra.atlassian.net/wiki/spaces/PEC/pages/15607956078/Pull+Request+Template
+-->
+
+### Description of your changes
+
+<!--
+Please include a short summary of the changes and any relevant
+motivation and context. List any dependencies that are required
+for this change (i.e. Depends on merge of PR in another repo).
+-->
+
+### JIRA reference
+
+<!-- DEV-123 etc. -->
+
+---
+
+### Impact Analysis
+
+<!--
+Please include any information about analysis that has been
+performed with respect to whether or not this change may have
+a potentially large or small impact on this or other codebases.
+-->
+
+---
+
+#### Checklist
+
+- [ ] I have performed a self-review of my code
+- [ ] My code follows the contribution guidelines of this project
+- [ ] My changes generate no new warnings


### PR DESCRIPTION
# Description of your changes

Add the Collibra PR template here so that it is applied by default to all repositories. This will only apply to repos that do not have their own PR template. 

Added PEC as codeowners of this repo.

**Key changes** compared to #1 :
- `Screenshots` section got removed (because it was optional, not that useful for BE projects and could be added per repo as part of the customisation)
- removed the `Type of change section` as we would like to standardise the use of conventional commits across the entire company
- `Checklist` section only contains 3 tasks and reworded the `style/formatting guidelines` to `My code follows the contribution guidelines of this project`

# JIRA reference
[PEC-54](https://engineering-collibra.atlassian.net/browse/PEC-54)

# Impact Analysis
This will impact all repos that do not already have a PR template in place.