### PR TITLE
ARCH-4643 Add CODEOWNERS allowlist mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+.claude/

--- a/scripts/check-codeowners.bats
+++ b/scripts/check-codeowners.bats
@@ -64,6 +64,78 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# load_allowlist
+# ---------------------------------------------------------------------------
+
+@test "load_allowlist: empty output for empty file" {
+    touch "$FIXTURE_DIR/allowlist.txt"
+    run load_allowlist "$FIXTURE_DIR/allowlist.txt"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "load_allowlist: empty output for missing file" {
+    run load_allowlist "$FIXTURE_DIR/does-not-exist.txt"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "load_allowlist: ignores comments and blank lines" {
+    printf "# a comment\n\n# another\n   \n" > "$FIXTURE_DIR/allowlist.txt"
+    run load_allowlist "$FIXTURE_DIR/allowlist.txt"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "load_allowlist: returns entries from a mixed file" {
+    printf "# header\n@bot-one\n\n@bot-two\n# trailing\n" > "$FIXTURE_DIR/allowlist.txt"
+    run load_allowlist "$FIXTURE_DIR/allowlist.txt"
+    [ "$status" -eq 0 ]
+    [ "$output" = "@bot-one"$'\n'"@bot-two" ]
+}
+
+@test "load_allowlist: trims surrounding whitespace" {
+    printf "  @spaced-bot  \n\t@tabbed-bot\t\n" > "$FIXTURE_DIR/allowlist.txt"
+    run load_allowlist "$FIXTURE_DIR/allowlist.txt"
+    [ "$status" -eq 0 ]
+    [ "$output" = "@spaced-bot"$'\n'"@tabbed-bot" ]
+}
+
+# ---------------------------------------------------------------------------
+# filter_against_allowlist
+# ---------------------------------------------------------------------------
+
+@test "filter_against_allowlist: empty allowlist preserves all input" {
+    run bash -c 'source "'"$BATS_TEST_DIRNAME"'/check-codeowners.sh"; printf "@alice\n@bob\n" | filter_against_allowlist ""'
+    [ "$status" -eq 0 ]
+    [ "$output" = "@alice"$'\n'"@bob" ]
+}
+
+@test "filter_against_allowlist: removes matching entries" {
+    run bash -c 'source "'"$BATS_TEST_DIRNAME"'/check-codeowners.sh"; printf "@alice\n@bot\n@bob\n" | filter_against_allowlist "@bot"'
+    [ "$status" -eq 0 ]
+    [ "$output" = "@alice"$'\n'"@bob" ]
+}
+
+@test "filter_against_allowlist: removes multiple matches" {
+    run bash -c 'source "'"$BATS_TEST_DIRNAME"'/check-codeowners.sh"; printf "@alice\n@bot-one\n@bob\n@bot-two\n" | filter_against_allowlist "@bot-one"$'"'"'\n'"'"'"@bot-two"'
+    [ "$status" -eq 0 ]
+    [ "$output" = "@alice"$'\n'"@bob" ]
+}
+
+@test "filter_against_allowlist: empty output when all entries are allowlisted" {
+    run bash -c 'source "'"$BATS_TEST_DIRNAME"'/check-codeowners.sh"; printf "@bot\n" | filter_against_allowlist "@bot"'
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "filter_against_allowlist: empty input passes through cleanly" {
+    run bash -c 'source "'"$BATS_TEST_DIRNAME"'/check-codeowners.sh"; printf "" | filter_against_allowlist "@bot"'
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
 # find_codeowners
 # ---------------------------------------------------------------------------
 
@@ -121,4 +193,29 @@ teardown() {
 @test "main: passes when no CODEOWNERS file exists" {
     run main "$FIXTURE_DIR"
     [ "$status" -eq 0 ]
+}
+
+@test "main: passes when only allowlisted individual is present" {
+    printf "@allowed-bot\n" > "$FIXTURE_DIR/allowlist.txt"
+    printf "* @org/team @allowed-bot\n" > "$FIXTURE_DIR/CODEOWNERS"
+    CODEOWNERS_ALLOWLIST_FILE="$FIXTURE_DIR/allowlist.txt" run main "$FIXTURE_DIR"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Allowed via allowlist: @allowed-bot"* ]]
+}
+
+@test "main: fails on disallowed individual but reports allowlisted exemption" {
+    printf "@allowed-bot\n" > "$FIXTURE_DIR/allowlist.txt"
+    printf "* @org/team @allowed-bot @human\n" > "$FIXTURE_DIR/CODEOWNERS"
+    CODEOWNERS_ALLOWLIST_FILE="$FIXTURE_DIR/allowlist.txt" run main "$FIXTURE_DIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Allowed via allowlist: @allowed-bot"* ]]
+    [[ "$output" == *"@human"* ]]
+    [[ "$output" != *"Offending entries:"*"@allowed-bot"* ]]
+}
+
+@test "main: fails for non-allowlisted individual when allowlist file is missing" {
+    printf "* @human\n" > "$FIXTURE_DIR/CODEOWNERS"
+    CODEOWNERS_ALLOWLIST_FILE="$FIXTURE_DIR/does-not-exist.txt" run main "$FIXTURE_DIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"@human"* ]]
 }

--- a/scripts/check-codeowners.sh
+++ b/scripts/check-codeowners.sh
@@ -25,6 +25,31 @@ extract_individuals() {
         || true
 }
 
+# Load allowlist entries from FILE. Strips full-line comments (# prefix after
+# trimming), blank lines, and surrounding whitespace. Missing file → empty
+# output (no error) so removing the allowlist falls back to strict enforcement.
+load_allowlist() {
+    local file="$1"
+    [[ -f "$file" ]] || return 0
+    awk '
+        { gsub(/^[[:space:]]+|[[:space:]]+$/, "") }
+        /^$/ { next }
+        /^#/ { next }
+        { print }
+    ' "$file"
+}
+
+# Filter stdin against ALLOWLIST (newline-separated). Drops exact matches,
+# prints survivors. Empty allowlist → passthrough.
+filter_against_allowlist() {
+    local allowlist="$1"
+    if [[ -z "$allowlist" ]]; then
+        cat
+        return 0
+    fi
+    grep -Fxv -f <(printf '%s\n' "$allowlist") || true
+}
+
 main() {
     local root="${1:-.}"
     local codeowners_file
@@ -36,18 +61,36 @@ main() {
 
     echo "Checking $codeowners_file ..."
 
-    local individuals
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    local allowlist_file="${CODEOWNERS_ALLOWLIST_FILE:-${script_dir}/codeowners-allowlist.txt}"
+    local allowlist
+    allowlist=$(load_allowlist "$allowlist_file")
+
+    local individuals disallowed allowed_matches
     individuals=$(extract_individuals "$codeowners_file")
 
-    if [[ -n "$individuals" ]]; then
+    if [[ -z "$individuals" ]]; then
+        echo "All CODEOWNERS entries are team references."
+        return 0
+    fi
+
+    disallowed=$(printf '%s\n' "$individuals" | filter_against_allowlist "$allowlist")
+    allowed_matches=$(printf '%s\n' "$individuals" | { [[ -n "$allowlist" ]] && grep -Fxf <(printf '%s\n' "$allowlist") || true; })
+
+    if [[ -n "$allowed_matches" ]]; then
+        echo "Allowed via allowlist: $(echo "$allowed_matches" | paste -sd, -)"
+    fi
+
+    if [[ -n "$disallowed" ]]; then
         echo "::error file=$codeowners_file::Individual users are not permitted in CODEOWNERS — use @org/team references instead."
         echo ""
         echo "Offending entries:"
-        echo "$individuals"
+        echo "$disallowed"
         exit 1
     fi
 
-    echo "All CODEOWNERS entries are team references."
+    echo "All CODEOWNERS entries are team references or allowlisted."
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/scripts/codeowners-allowlist.txt
+++ b/scripts/codeowners-allowlist.txt
@@ -1,0 +1,10 @@
+# Individual @mentions that are exempt from the "teams only" CODEOWNERS policy
+# enforced by scripts/check-codeowners.sh.
+#
+# Add only bot/service accounts — never humans. Humans must own code via team
+# membership so that ownership survives org changes and PTO.
+#
+# One @username per line. Blank lines and # comments are ignored.
+# Entries are matched exactly against tokens extracted from CODEOWNERS.
+
+@collibra-cicd-auto-merge


### PR DESCRIPTION
### Description of your changes

Adds a maintainable allowlist mechanism to the org-wide team-only CODEOWNERS enforcement (`scripts/check-codeowners.sh`), enabling specific bot/service accounts to be designated code-owners without violating the policy. Initial allowlist exempts `@collibra-cicd-auto-merge`, which is already used as a code-owner across ~20 active edge-family repos for auto-merge flows. Without this exemption, those repos would immediately fail the next PR once enforcement is enabled.

**Design**
- New file `scripts/codeowners-allowlist.txt` — one `@username` per line, `#` comments and blank lines ignored. Lives alongside the script in the `.github` org repo so consumer repos cannot ship their own (preserves the policy).
- Two new helpers in `check-codeowners.sh`: `load_allowlist` and `filter_against_allowlist`. Existing `extract_individuals` and `find_codeowners` are untouched.
- `main()` resolves the allowlist via `CODEOWNERS_ALLOWLIST_FILE` env var (defaults to `<script_dir>/codeowners-allowlist.txt`), filters out exempt entries, and logs which exemptions actually matched in this run for CI transparency.
- Missing allowlist file → treated as empty (no error). Keeps backward compatibility if the file is removed.
- 13 new bats tests covering both helpers and three new `main()` integration scenarios. Mutation-tested (disabled the filter, watched integration tests fail) to confirm the new tests catch real behavior rather than incidental code paths.

**Audit context**
A full org-wide audit of CODEOWNERS files was run before this change to identify violators. Results (active, non-archived repos): 491 with CODEOWNERS, 455 passing, 36 violating. Of the 36, 20 are the `@collibra-cicd-auto-merge` bot (this allowlist resolves them), 2 are forks of upstream OSS where the CODEOWNERS file mirrors upstream, and 14 contain real human individuals that the respective teams will need to convert to team references before strict enforcement.

---

### JIRA reference

ARCH-4643

---

### Impact Analysis

- **Behavior preserved** for the existing pass/fail cases (verified by the 16 pre-existing bats tests, all still green).
- **One new behavior**: CODEOWNERS files containing only allowlisted bots now pass instead of failing.
- **Org-wide scope only**: consumer repos cannot override the allowlist — the script reads the allowlist that ships in `.github-shared/`, not from the consumer repo.
- **No workflow changes**: `enforce-codeowners-teams.yml` already loads the script from the `.github` org checkout; `test-scripts.yml`'s `scripts/**` path filter picks up the new file automatically.
- **Failure-mode regression**: the failure path (when disallowed individuals are present) still reports via `::error file=...` and exits 1, matching prior behavior.

---

#### Checklist

- [x] I have performed a self-review of my code
- [x] My code follows the contribution guidelines of this project
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)