### PR TITLE
ARCH-4643 Skip fork repos in CODEOWNERS enforcement

### DIFF
--- a/org-workflows/enforce-codeowners-teams.yml
+++ b/org-workflows/enforce-codeowners-teams.yml
@@ -11,6 +11,10 @@ on:
 jobs:
   check-codeowners:
     name: CODEOWNERS — teams only
+    # Skip forks: their CODEOWNERS is inherited from upstream and not ours to
+    # govern, so enforcing teams-only there would fail every PR for no benefit.
+    # A skipped job still satisfies the required-workflow check.
+    if: ${{ !github.event.repository.fork }}
     runs-on:
       - runs-on=${{ github.run_id }}
       - runner=tn


### PR DESCRIPTION
## What

Guards the `Enforce team-only CODEOWNERS` required workflow with `if: ${{ !github.event.repository.fork }}` so it no longer runs on fork repos.

## Why

Forks inherit their CODEOWNERS from upstream — those files contain individual contributors we don't govern, so the teams-only policy would fail every PR on them for no benefit (e.g. `collibra/DefinitelyTyped`, `collibra/opentelemetry-collector-contrib`). A skipped job still satisfies the required-workflow check, so org-wide enforcement is unaffected for the repos we do own.

## Context

Follow-up to the CODEOWNERS allowlist mechanism. An org-wide audit (1393 non-archived, non-fork repos) found 9 repos still using individual human owners that need migrating to `@collibra/<team>` references — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)